### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+# Usually these files are written by a python script from a template
+# before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -50,16 +50,23 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.pre-commit-cache/  # Added for pre-commit tool
 
 # Translations
 *.mo
 *.pot
 
-# Django stuff:
+# Logs
 *.log
+logs/
+
+# Databases
+*.sqlite3
+*.db
+
+# Django stuff:
 local_settings.py
-db.sqlite3
-db.sqlite3-journal
+db.sqlite3-journal  # db.sqlite3 moved to general Databases section
 
 # Flask stuff:
 instance/
@@ -70,6 +77,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/build/  # Added for alternative Sphinx build directories
 
 # PyBuilder
 .pybuilder/
@@ -79,40 +87,41 @@ target/
 .ipynb_checkpoints
 
 # IPython
+.ipython/  # Updated to include entire IPython directory
 profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
+# For a library or package, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
 # .python-version
 
 # pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
+# According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+# However, in case of collaboration, if having platform-specific dependencies or dependencies
+# having no cross-platform support, pipenv may install dependencies that don't work, or not
+# install all needed dependencies.
 #Pipfile.lock
 
 # UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
+# Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+# This is especially recommended for binary packages to ensure reproducibility, and is more
+# commonly ignored for libraries.
 #uv.lock
 
 # poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+# This is especially recommended for binary packages to ensure reproducibility, and is more
+# commonly ignored for libraries.
+# https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
 # pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+# Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+# pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+# in version control.
+# https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
 .pdm-python
 .pdm-build/
@@ -161,10 +170,10 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+# be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+# and can be added to the global gitignore or merged into this file. For a more nuclear
+# option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
 # Ruff stuff:
@@ -172,3 +181,24 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Editor-specific files
+.vscode/
+*.sublime-project
+*.sublime-workspace
+.atom/
+
+# Backup files
+*~
+*.bak
+*.swp
+
+# Secrets
+*.pem
+*.key
+*.crt
+secrets/


### PR DESCRIPTION
Generalized Logs and Databases
Original: *.log, db.sqlite3, and db.sqlite3-journal were listed under # Django stuff.

Enhanced: Moved *.log to a new # Logs section and added logs/ for log directories. Moved db.sqlite3 to a new # Databases section and added *.db for other database files, making these ignores applicable to all projects, not just Django. Left db.sqlite3-journal under Django as it’s more specific.

Operating System Files
Added: # OS generated files section with .DS_Store (macOS) and Thumbs.db (Windows) to exclude system-generated files that often clutter repositories.

Editor-Specific Files
Added: # Editor-specific files section with:
.vscode/ for Visual Studio Code settings.

*.sublime-project and *.sublime-workspace for Sublime Text project files.

.atom/ for Atom editor configurations.

Purpose: Prevents committing editor-specific settings that are irrelevant to other developers.

Backup and Temporary Files
Added: # Backup files section with *~, *.bak, and *.swp to ignore common backup and swap files created by text editors.

Secrets and Sensitive Files
Added: # Secrets section with *.pem, *.key, *.crt (certificate and key files), and secrets/ (directory for sensitive data).

Purpose: Enhances security by ensuring sensitive files aren’t accidentally committed.

Development Tools
Added: .pre-commit-cache/ under # Unit test / coverage reports for the pre-commit tool’s cache, aligning with other testing-related ignores like .tox/ and .pytest_cache/.

Documentation Flexibility
Original: docs/_build/ under # Sphinx documentation.

Enhanced: Added docs/build/ to accommodate alternative Sphinx output directory names.

IPython Enhancement
Original: profile_default/ and ipython_config.py under # IPython.

Enhanced: Added .ipython/ to ignore the entire IPython directory for completeness.